### PR TITLE
feat: VS Code 扩展支持 Sync to Bridge（MVP）

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@
 
 ## 配置项
 
-在 VS Code 设置中搜索 `Codex Chat Exporter`：
+在 VS Code 设置中搜索 `Codex Chat Exporter` / `codexChatExporter`，或在命令面板运行 `Preferences: Open Settings (JSON)` 直接编辑：
 
 - `codexChatExporter.codexDir`：Codex 数据目录（默认 `~/.codex`）
-- `codexChatExporter.onlyVsCodeSessions`：仅显示/导出 VS Code 会话
+- `codexChatExporter.onlyVsCodeSessions`：仅显示/导出 VS Code 会话（关闭后可看到 `codex_cli_rs` 等 CLI 会话）
 - `codexChatExporter.includeAgentReasoning`：Markdown 中包含 reasoning
 - `codexChatExporter.includeToolCalls`：Markdown 中包含工具调用
 - `codexChatExporter.includeToolOutputs`：Markdown 中包含工具输出（可能包含敏感信息）
@@ -54,3 +54,5 @@
 - `codexChatExporter.defaultDoneDefinition`：同步时默认 Done 标准（可选）
 - `codexChatExporter.syncIncludeRawJsonl`：同步时包含原始 JSONL
 - `codexChatExporter.syncIncludeMarkdown`：同步时包含 Markdown
+
+> 如果你在 WSL/Remote 环境运行扩展，但 Codex 会话在 Windows（例如 `C:\\Users\\GuoYW\\.codex`），可以把 `codexChatExporter.codexDir` 设置为 `/mnt/c/Users/GuoYW/.codex`。

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         },
         "codexChatExporter.onlyVsCodeSessions": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "只显示/导出 VS Code 发起的会话（originator=codex_vscode 或 source=vscode）。"
         },
         "codexChatExporter.includeAgentReasoning": {


### PR DESCRIPTION
## 背景
按 `docs/ai-learning-os/SPECS/10-vscode-extension-sync.md` 增加“一键同步到 Bridge（MVP）”，在现有导出能力基础上支持将选中的 Codex 会话导入 Bridge，便于后续复盘/资产化。

## 主要变更
- 新增命令（命令面板可用）：
  - `Codex: 同步聊天记录到 Bridge`（`codexChatExporter.syncToBridge`）
  - `Codex: 同步最近一次聊天记录到 Bridge`（`codexChatExporter.syncLatestToBridge`）
- 新增设置项：
  - `codexChatExporter.bridgeBaseUrl`（默认 `http://127.0.0.1:7331`）
  - `codexChatExporter.defaultProjectName`（默认空）
  - `codexChatExporter.defaultDoneDefinition`（默认空）
  - `codexChatExporter.syncIncludeRawJsonl`（默认 `true`）
  - `codexChatExporter.syncIncludeMarkdown`（默认 `false`）
- 同步逻辑（`extension.js`）：
  - 复用现有会话选择逻辑（支持多选；支持最近一次）
  - `project_name` 默认优先使用 workspace folder 名（否则引导输入）
  - 读取被选中的 `.jsonl` 内容并调用：
    - `POST {bridgeBaseUrl}/bridge/v1/import/codex-chat`
  - 进度条逐个同步；单个会话失败不影响其它会话
  - Bridge 不可达或返回非 2xx：给出明确错误提示
  - Bridge 返回 `project_id/session_id`：在成功提示里展示
- README 增加使用说明与配置说明

## 隐私/安全默认策略
- 同步默认不上传 tool outputs 与 `<environment_context>`（除非你在设置中显式开启相关导出选项）。
- 未新增第三方依赖；仅使用 Node 内置 `http/https`。

## 如何验收（手工测试）
1. 启动 Extension Development Host（F5）。
2. 确认命令面板存在：
   - `Codex: 同步聊天记录到 Bridge`
3. Bridge 未启动时执行同步：
   - 期望出现“无法连接 Bridge … 请确认 Bridge 已启动”的清晰报错。
4. Bridge 启动后执行同步（可多选会话）：
   - 期望逐个同步并展示进度；
   - 成功提示中出现 `project_id`/`session_id`；
   - 某个会话失败不影响其它会话继续。

## 变更范围
仅修改：`extension.js`、`package.json`、`README.md`。
