### PR TITLE
Add Replay stub routes + deep links

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -20,12 +20,17 @@ Service listens on `127.0.0.1:7331` by default.
 - `BRIDGE_HOST` (default: `127.0.0.1`)
 - `BRIDGE_PORT` (default: `7331`)
 - `BRIDGE_DB_PATH` (default: `bridge/.data/bridge.db`)
+- `BRIDGE_PUBLIC_BASE_URL` (optional, e.g. `http://127.0.0.1:7331`)
+  - Used to generate **absolute** `Open in Replay` links for exported/published Markdown.
 
 ## Endpoints
+- `GET /replay` -> Replay index (stub UI)
+- `GET /replay/projects/{project_id}/sessions/{session_id}` -> Replay session transcript (stub UI; anchors like `#m-000123`)
 - `GET /bridge/v1/health` -> `ok`
 - `POST /bridge/v1/import/codex-chat`
 - `POST /bridge/v1/projects/{project_id}/generate` -> `501 Not Implemented` (MVP)
-- `POST /bridge/v1/projects/{project_id}/sync/open-notebook` -> `501 Not Implemented` (MVP)
+- `POST /bridge/v1/projects/{project_id}/sync/open-notebook` -> Sync Sources + placeholder Notes into OpenNotebook FS adapter
+  - If `BRIDGE_PUBLIC_BASE_URL` is set, Notes include `Open in Replay` deep links like `{BRIDGE_PUBLIC_BASE_URL}/replay/projects/{project_id}/sessions/{session_id}#m-000123`.
 
 ## Troubleshooting
 - 如果在 WSL 里跑到了 Windows 的 `node/npm`（路径里出现 `D:\\...`），容易出现依赖二进制不匹配问题；建议统一在同一环境里执行 `npm install` + `npm start`（WSL 用 Linux Node，Windows 用 PowerShell/CMD）。

--- a/bridge/fixtures/replay-session.jsonl
+++ b/bridge/fixtures/replay-session.jsonl
@@ -1,0 +1,4 @@
+{"type":"event_msg","timestamp":"2026-01-01T00:00:00.000Z","payload":{"type":"user_message","message":"Hello Replay stub!\\nThis line contains HTML-like text: <script>alert(1)</script>"}}
+{"type":"event_msg","timestamp":"2026-01-01T00:00:01.000Z","payload":{"type":"agent_message","message":"Got it. Here is a code block:\\n\\n```js\\nconsole.log('hi')\\n```"}}
+{"type":"event_msg","timestamp":"2026-01-01T00:00:02.000Z","payload":{"type":"user_message","message":"Can you summarize the last response?"}}
+{"type":"event_msg","timestamp":"2026-01-01T00:00:03.000Z","payload":{"type":"agent_message","message":"Summary: It contained a JavaScript code block printing 'hi'."}}

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -6,7 +6,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "verify:replay": "node scripts/verify-replay-fixture.js"
   },
   "dependencies": {
     "express": "^4.19.2"

--- a/bridge/scripts/verify-replay-fixture.js
+++ b/bridge/scripts/verify-replay-fixture.js
@@ -1,0 +1,49 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const { parseCodexJsonl } = require("../src/lib/codexJsonl");
+const { messageIdForIndex } = require("../src/lib/messageIds");
+const { renderReplaySessionHtml } = require("../src/lib/replayHtml");
+const { replaySessionPath } = require("../src/lib/replayUrls");
+
+function main() {
+  const fixturePath = path.join(__dirname, "..", "fixtures", "replay-session.jsonl");
+  const jsonlText = fs.readFileSync(fixturePath, "utf8");
+
+  const { messages, message_count } = parseCodexJsonl(jsonlText);
+  assert.strictEqual(message_count, messages.length);
+  assert.strictEqual(messages.length, 4);
+
+  assert.strictEqual(messageIdForIndex(0), "m-000001");
+  assert.strictEqual(messageIdForIndex(3), "m-000004");
+
+  const project = { id: "proj_fixture", name: "Fixture Project" };
+  const session = { id: "sess_fixture", name: "Fixture Session" };
+  const html = renderReplaySessionHtml({ project, session, messages });
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const id = messageIdForIndex(i);
+    assert.ok(html.includes(`id=\"${id}\"`), `missing anchor id=${id}`);
+    assert.ok(html.includes(`href=\"#${id}\"`), `missing self-link href=#${id}`);
+  }
+
+  assert.ok(
+    html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"),
+    "expected message text to be HTML-escaped",
+  );
+
+  assert.strictEqual(
+    replaySessionPath(project.id, session.id),
+    "/replay/projects/proj_fixture/sessions/sess_fixture",
+  );
+
+  // If you want to verify manually in the browser:
+  // - Start the Bridge server: `cd bridge && npm install && npm start`
+  // - Import the fixture via POST /bridge/v1/import/codex-chat
+  // - Open: http://127.0.0.1:7331/replay
+
+  console.log("ok: replay fixture anchors are stable and linkable");
+}
+
+main();

--- a/bridge/src/db.js
+++ b/bridge/src/db.js
@@ -93,6 +93,10 @@ function makeBridgeDb(db, driver) {
     return statements.getLatestSourceBySessionId.get({ session_id }) || null;
   }
 
+  function listRecentSessions({ limit }) {
+    return statements.listRecentSessions.all({ limit }) || [];
+  }
+
   return {
     db,
     driver,
@@ -103,6 +107,7 @@ function makeBridgeDb(db, driver) {
     getProjectById,
     getSessionById,
     getLatestSourceBySessionId,
+    listRecentSessions,
     close: () => {
       if (typeof db.close === "function") db.close();
     },
@@ -148,6 +153,19 @@ function prepareStatements(db) {
        WHERE session_id = @session_id
        ORDER BY created_at DESC
        LIMIT 1`,
+    ),
+    listRecentSessions: db.prepare(
+      `SELECT
+         s.id AS session_id,
+         s.project_id AS project_id,
+         s.name AS session_name,
+         s.imported_at AS imported_at,
+         p.name AS project_name,
+         p.cwd AS project_cwd
+       FROM sessions s
+       JOIN projects p ON p.id = s.project_id
+       ORDER BY s.imported_at DESC
+       LIMIT @limit`,
     ),
   };
 }

--- a/bridge/src/lib/messageIds.js
+++ b/bridge/src/lib/messageIds.js
@@ -1,0 +1,10 @@
+function messageIdForIndex(index) {
+  const n = Number(index) + 1;
+  return `m-${String(n).padStart(6, "0")}`;
+}
+
+function isValidMessageId(messageId) {
+  return /^m-\d{6}$/.test(String(messageId || ""));
+}
+
+module.exports = { isValidMessageId, messageIdForIndex };

--- a/bridge/src/lib/replayHtml.js
+++ b/bridge/src/lib/replayHtml.js
@@ -1,0 +1,202 @@
+const { messageIdForIndex, isValidMessageId } = require("./messageIds");
+const { replayIndexPath, replaySessionPath } = require("./replayUrls");
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderLayout({ title, bodyHtml }) {
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `<title>${escapeHtml(title)}</title>`,
+    "<style>",
+    "  :root {",
+    "    color-scheme: light dark;",
+    "    --bg: #0b0f19;",
+    "    --panel: rgba(255, 255, 255, 0.06);",
+    "    --text: #e6e6e6;",
+    "    --muted: rgba(230, 230, 230, 0.7);",
+    "    --link: #7aa2ff;",
+    "    --border: rgba(255, 255, 255, 0.14);",
+    "    --target: rgba(255, 215, 0, 0.16);",
+    "  }",
+    "  @media (prefers-color-scheme: light) {",
+    "    :root {",
+    "      --bg: #fafafa;",
+    "      --panel: rgba(0, 0, 0, 0.04);",
+    "      --text: #111827;",
+    "      --muted: rgba(17, 24, 39, 0.7);",
+    "      --link: #2457ff;",
+    "      --border: rgba(0, 0, 0, 0.12);",
+    "      --target: rgba(255, 204, 0, 0.22);",
+    "    }",
+    "  }",
+    "  html, body { height: 100%; }",
+    "  body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;",
+    "         background: var(--bg); color: var(--text); }",
+    "  a { color: var(--link); text-decoration: none; }",
+    "  a:hover { text-decoration: underline; }",
+    "  .wrap { max-width: 1100px; margin: 0 auto; padding: 20px; }",
+    "  .header { display: flex; gap: 12px; align-items: baseline; justify-content: space-between; margin-bottom: 16px; }",
+    "  .header h1 { font-size: 18px; margin: 0; }",
+    "  .muted { color: var(--muted); }",
+    "  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px; }",
+    "  .list { list-style: none; padding: 0; margin: 0; }",
+    "  .list li { padding: 10px 0; border-top: 1px solid var(--border); }",
+    "  .list li:first-child { border-top: none; }",
+    "  .row { display: flex; gap: 12px; justify-content: space-between; }",
+    "  .row .meta { display: flex; flex-direction: column; gap: 4px; }",
+    "  .row .meta .title { font-weight: 600; }",
+    "  .row .meta .sub { font-size: 12px; color: var(--muted); }",
+    "  .messages { list-style: none; padding: 0; margin: 0; }",
+    "  .message { border-top: 1px solid var(--border); padding: 14px 10px; }",
+    "  .message:first-child { border-top: none; }",
+    "  .message:target { background: var(--target); outline: 2px solid rgba(255, 215, 0, 0.3); border-radius: 10px; }",
+    "  .msg-head { display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap; }",
+    "  .msg-head .id { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-weight: 700; }",
+    "  .msg-head .role { padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); font-size: 12px; }",
+    "  .msg-head .ts { font-size: 12px; color: var(--muted); }",
+    "  .msg-body { margin-top: 8px; }",
+    "  .msg-body pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; line-height: 1.45;",
+    "               font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 13px; }",
+    "</style>",
+    "</head>",
+    "<body>",
+    `<div class="wrap">${bodyHtml}</div>`,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+function renderReplayErrorHtml({ title, message }) {
+  const body = [
+    '<div class="header">',
+    `  <h1>${escapeHtml(title || "Replay")}</h1>`,
+    `  <div><a href="${replayIndexPath()}">Replay index</a></div>`,
+    "</div>",
+    '<div class="panel">',
+    `  <p>${escapeHtml(message || "Unexpected error.")}</p>`,
+    "</div>",
+  ].join("\n");
+
+  return renderLayout({ title: title || "Replay Error", bodyHtml: body });
+}
+
+function renderReplayIndexHtml({ sessions }) {
+  const listHtml = Array.isArray(sessions) && sessions.length
+    ? [
+        '<ul class="list">',
+        ...sessions.map((s) => {
+          const href = replaySessionPath(s.project_id, s.session_id);
+          const title = `${s.project_name || s.project_id} / ${s.session_name || s.session_id}`;
+          const sub = [
+            s.imported_at ? `imported_at: ${s.imported_at}` : null,
+            `project_id: ${s.project_id}`,
+            `session_id: ${s.session_id}`,
+          ]
+            .filter(Boolean)
+            .join(" · ");
+
+          return [
+            "<li>",
+            '  <div class="row">',
+            '    <div class="meta">',
+            `      <div class="title"><a href="${href}">${escapeHtml(title)}</a></div>`,
+            `      <div class="sub">${escapeHtml(sub)}</div>`,
+            "    </div>",
+            "  </div>",
+            "</li>",
+          ].join("\n");
+        }),
+        "</ul>",
+      ].join("\n")
+    : `<p class="muted">No sessions imported yet. Import via <code>POST /bridge/v1/import/codex-chat</code>.</p>`;
+
+  const body = [
+    '<div class="header">',
+    "  <h1>Replay</h1>",
+    '  <div class="muted">Stub UI</div>',
+    "</div>",
+    '<div class="panel">',
+    "  <p class=\"muted\">Select a session:</p>",
+    `  ${listHtml}`,
+    "</div>",
+  ].join("\n");
+
+  return renderLayout({ title: "Replay", bodyHtml: body });
+}
+
+function renderReplaySessionHtml({ project, session, messages }) {
+  const projectLabel = project && typeof project === "object" ? project.name || project.id : "";
+  const sessionLabel = session && typeof session === "object" ? session.name || session.id : "";
+
+  const metaLines = [];
+  if (project && project.id) metaLines.push(`project_id: ${project.id}`);
+  if (session && session.id) metaLines.push(`session_id: ${session.id}`);
+
+  const list = Array.isArray(messages)
+    ? messages
+        .map((m, i) => {
+          const id = messageIdForIndex(i);
+          const role = m && typeof m === "object" && typeof m.role === "string" ? m.role : "unknown";
+          const ts = m && typeof m === "object" && typeof m.timestamp === "string" ? m.timestamp : "";
+          const text = m && typeof m === "object" && typeof m.text === "string" ? m.text : "";
+
+          const displayTs = ts ? escapeHtml(ts) : "";
+          const displayRole = escapeHtml(role);
+
+          return [
+            `<li class="message" id="${id}">`,
+            '  <div class="msg-head">',
+            `    <a class="id" href="#${id}">${id}</a>`,
+            `    <span class="role">${displayRole}</span>`,
+            displayTs ? `    <span class="ts">${displayTs}</span>` : "",
+            "  </div>",
+            '  <div class="msg-body">',
+            `    <pre>${escapeHtml(text)}</pre>`,
+            "  </div>",
+            "</li>",
+          ]
+            .filter(Boolean)
+            .join("\n");
+        })
+        .join("\n")
+    : "";
+
+  const body = [
+    '<div class="header">',
+    `  <h1>${escapeHtml([projectLabel, sessionLabel].filter(Boolean).join(" / ") || "Replay Session")}</h1>`,
+    `  <div><a href="${replayIndexPath()}">Replay index</a></div>`,
+    "</div>",
+    '<div class="panel">',
+    metaLines.length ? `  <div class="muted">${escapeHtml(metaLines.join(" · "))}</div>` : "",
+    Array.isArray(messages) && messages.length ? `  <ol class="messages">${list}</ol>` : '  <p class="muted">No messages found.</p>',
+    "</div>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return renderLayout({ title: "Replay Session", bodyHtml: body });
+}
+
+function looksLikeMessageHash(hash) {
+  const raw = String(hash || "");
+  const decoded = raw.startsWith("#") ? decodeURIComponent(raw.slice(1)) : decodeURIComponent(raw);
+  return isValidMessageId(decoded);
+}
+
+module.exports = {
+  looksLikeMessageHash,
+  renderReplayErrorHtml,
+  renderReplayIndexHtml,
+  renderReplaySessionHtml,
+};

--- a/bridge/src/lib/replayUrls.js
+++ b/bridge/src/lib/replayUrls.js
@@ -1,0 +1,35 @@
+function replayIndexPath() {
+  return "/replay";
+}
+
+function replaySessionPath(projectId, sessionId) {
+  const p = encodeURIComponent(String(projectId || ""));
+  const s = encodeURIComponent(String(sessionId || ""));
+  return `/replay/projects/${p}/sessions/${s}`;
+}
+
+function getBridgePublicBaseUrl(env = process.env) {
+  const raw = String(env.BRIDGE_PUBLIC_BASE_URL || "").trim();
+  if (!raw) return null;
+
+  const normalized = raw.replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(normalized)) return null;
+  return normalized;
+}
+
+function replaySessionUrl({ projectId, sessionId, baseUrl }) {
+  const path = replaySessionPath(projectId, sessionId);
+  return baseUrl ? `${baseUrl}${path}` : path;
+}
+
+function replayMessageUrl({ projectId, sessionId, messageId, baseUrl }) {
+  return `${replaySessionUrl({ projectId, sessionId, baseUrl })}#${encodeURIComponent(String(messageId || ""))}`;
+}
+
+module.exports = {
+  getBridgePublicBaseUrl,
+  replayIndexPath,
+  replayMessageUrl,
+  replaySessionPath,
+  replaySessionUrl,
+};


### PR DESCRIPTION
Implements OpenSpec change `add-replay-stub`.

- Adds canonical Replay URL helpers and `BRIDGE_PUBLIC_BASE_URL` support for absolute deep links
- Adds stub Replay routes: `/replay` and `/replay/projects/{project_id}/sessions/{session_id}` with stable `#m-000123` anchors
- Adds a small fixture + script to verify anchors are stable/linkable

Closes #14
Closes #15
Closes #16