### PR TITLE
Expand privacy redaction

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -6,7 +6,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "test": "node test/redact.test.js"
   },
   "dependencies": {
     "express": "^4.19.2"

--- a/bridge/src/adapters/filesystem.js
+++ b/bridge/src/adapters/filesystem.js
@@ -3,6 +3,7 @@ const fs = require("fs/promises");
 const path = require("path");
 
 const { OpenNotebookAdapter } = require("./adapter");
+const { redactForOpenNotebookMarkdown } = require("../lib/redact");
 
 const DEFAULT_ENV_VAR = "OPEN_NOTEBOOK_FS_ROOT";
 
@@ -198,6 +199,8 @@ class FilesystemAdapter extends OpenNotebookAdapter {
     assertNonEmpty(session, "session");
     assertNonEmpty(content, "content");
 
+    const sanitizedContent = redactForOpenNotebookMarkdown(content);
+
     const notebookDir = path.join(this.notebooksDir, notebookId);
     await assertDirectoryExists(notebookDir, "Notebook directory");
 
@@ -212,7 +215,7 @@ class FilesystemAdapter extends OpenNotebookAdapter {
       session,
     });
     try {
-      await fs.writeFile(sourcePath, `${frontMatter}${content}\n`, "utf8");
+      await fs.writeFile(sourcePath, `${frontMatter}${sanitizedContent}\n`, "utf8");
     } catch (error) {
       throw new Error(
         formatFsError(error, {
@@ -234,6 +237,8 @@ class FilesystemAdapter extends OpenNotebookAdapter {
       throw new Error("links must be an array of strings.");
     }
 
+    const sanitizedContent = redactForOpenNotebookMarkdown(content);
+
     const notebookDir = path.join(this.notebooksDir, notebookId);
     await assertDirectoryExists(notebookDir, "Notebook directory");
 
@@ -245,7 +250,7 @@ class FilesystemAdapter extends OpenNotebookAdapter {
       links,
     });
     try {
-      await fs.writeFile(notePath, `${frontMatter}${content}\n`, "utf8");
+      await fs.writeFile(notePath, `${frontMatter}${sanitizedContent}\n`, "utf8");
     } catch (error) {
       throw new Error(
         formatFsError(error, {

--- a/bridge/src/lib/redact.js
+++ b/bridge/src/lib/redact.js
@@ -1,3 +1,19 @@
+function redactPhoneNumbers(text) {
+  const input = String(text ?? "");
+
+  return input.replace(
+    /(^|[^0-9A-Za-z_])(\+?(?:\(\d|\d)[\d\s().-]{5,}\d)(?=[^0-9A-Za-z_]|$)/g,
+    (match, prefix, candidate) => {
+      const digits = String(candidate).replace(/\D/g, "");
+      if (digits.length < 7 || digits.length > 15) return match;
+
+      if (/^\d{4}[-/.]\d{2}[-/.]\d{2}$/.test(candidate)) return match;
+
+      return `${prefix}[REDACTED_PHONE]`;
+    },
+  );
+}
+
 function redactText(text) {
   let out = String(text ?? "");
 
@@ -8,12 +24,41 @@ function redactText(text) {
 
   out = out.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/g, "[REDACTED_API_KEY]");
 
+  out = out.replace(/\bgh[pousr]_[A-Za-z0-9]{36,255}\b/g, "[REDACTED_GITHUB_TOKEN]");
+  out = out.replace(/\bgithub_pat_[A-Za-z0-9_]{22,255}\b/g, "[REDACTED_GITHUB_TOKEN]");
+
+  out = out.replace(/\bxox[baprs]-[0-9A-Za-z-]{10,}\b/g, "[REDACTED_SLACK_TOKEN]");
+
   out = out.replace(
     /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
     "[REDACTED_PRIVATE_KEY]",
   );
 
+  out = out.replace(
+    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    "[REDACTED_EMAIL]",
+  );
+
+  out = redactPhoneNumbers(out);
+
   return out;
 }
 
-module.exports = { redactText };
+function redactForOpenNotebookMarkdown(markdown) {
+  return redactText(markdown);
+}
+
+function redactForExportMarkdown(markdown) {
+  return redactText(markdown);
+}
+
+function redactForOpenAIGenerationInput(text) {
+  return redactText(text);
+}
+
+module.exports = {
+  redactText,
+  redactForOpenNotebookMarkdown,
+  redactForExportMarkdown,
+  redactForOpenAIGenerationInput,
+};

--- a/bridge/test/redact.test.js
+++ b/bridge/test/redact.test.js
@@ -1,0 +1,107 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  redactText,
+  redactForExportMarkdown,
+  redactForOpenAIGenerationInput,
+  redactForOpenNotebookMarkdown,
+} = require("../src/lib/redact");
+
+test("redacts Authorization: Bearer tokens", () => {
+  const input = "Authorization: Bearer abc.def.ghi";
+  const out = redactText(input);
+  assert.equal(out, "Authorization: Bearer [REDACTED_TOKEN]");
+});
+
+test("redacts OpenAI-style sk- API keys", () => {
+  const key = ["s", "k"].join("") + "-" + "abcdefghijklmnopqrstuvwxyz123456";
+  const input = `key=${key}`;
+  const out = redactText(input);
+  assert.equal(out, "key=[REDACTED_API_KEY]");
+});
+
+test("redacts GitHub tokens", () => {
+  const ghp = ["gh", "p"].join("") + "_" + "a".repeat(36);
+  const fineGrained = ["github", "pat"].join("_") + "_" + "b".repeat(40);
+  const input = `tokens: ${ghp} ${fineGrained}`;
+  const out = redactText(input);
+  assert.equal(out, "tokens: [REDACTED_GITHUB_TOKEN] [REDACTED_GITHUB_TOKEN]");
+});
+
+test("redacts Slack tokens", () => {
+  const slack = ["xo", "xb"].join("") + "-1234567890-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const out = redactText(`slack=${slack}`);
+  assert.equal(out, "slack=[REDACTED_SLACK_TOKEN]");
+});
+
+test("redacts email addresses", () => {
+  const input = "Contact: test.user+tag@example.co.uk";
+  const out = redactText(input);
+  assert.equal(out, "Contact: [REDACTED_EMAIL]");
+});
+
+test("redacts phone numbers (best-effort)", () => {
+  const input = "Call +1 (415) 555-2671 now.";
+  const out = redactText(input);
+  assert.equal(out, "Call [REDACTED_PHONE] now.");
+});
+
+test("does not treat ISO dates as phone numbers", () => {
+  const input = "Date: 2026-01-04";
+  const out = redactText(input);
+  assert.equal(out, input);
+});
+
+test("redacts PEM private key blocks", () => {
+  const input = [
+    "```pem",
+    "-----BEGIN PRIVATE KEY-----",
+    "abc",
+    "-----END PRIVATE KEY-----",
+    "```",
+  ].join("\n");
+  const out = redactText(input);
+  assert.ok(out.includes("[REDACTED_PRIVATE_KEY]"));
+  assert.ok(!out.includes("BEGIN PRIVATE KEY"));
+});
+
+test("does not break basic markdown structure", () => {
+  const input = [
+    "# Title",
+    "",
+    "Email: test@example.com",
+    "",
+    "[Email](mailto:test@example.com)",
+    "",
+    "```sh",
+    "curl -H 'Authorization: Bearer abc' https://example.test",
+    "echo sk-abcdefghijklmnopqrstuvwxyz123456",
+    "```",
+    "",
+    "Call (415) 555-2671",
+    "",
+  ].join("\n");
+
+  const out = redactText(input);
+
+  const fenceCountIn = (input.match(/```/g) || []).length;
+  const fenceCountOut = (out.match(/```/g) || []).length;
+  assert.equal(fenceCountOut, fenceCountIn);
+
+  assert.ok(out.includes("# Title"));
+  assert.ok(out.includes("Email: [REDACTED_EMAIL]"));
+  assert.ok(out.includes("[Email](mailto:[REDACTED_EMAIL])"));
+  assert.ok(out.includes("Authorization: Bearer [REDACTED_TOKEN]"));
+  assert.ok(out.includes("[REDACTED_API_KEY]"));
+  assert.ok(out.includes("[REDACTED_PHONE]"));
+});
+
+test("use-case helpers behave like redactText for now", () => {
+  const key = ["s", "k"].join("") + "-" + "abcdefghijklmnopqrstuvwxyz123456";
+  const input = `Authorization: Bearer abc ${key}`;
+  const expected = redactText(input);
+  assert.equal(redactForOpenNotebookMarkdown(input), expected);
+  assert.equal(redactForExportMarkdown(input), expected);
+  assert.equal(redactForOpenAIGenerationInput(input), expected);
+});

--- a/openspec/changes/expand-privacy-redaction/specs/privacy-redaction/spec.md
+++ b/openspec/changes/expand-privacy-redaction/specs/privacy-redaction/spec.md
@@ -6,22 +6,44 @@ The system SHALL redact common secret patterns from downstream content.
 #### Scenario: Authorization bearer token
 - **WHEN** text contains `Authorization: Bearer <token>`
 - **THEN** the token is replaced with `[REDACTED_TOKEN]`
+- Pattern example: `(Authorization:\\s*Bearer\\s+)[^\\s]+`
+- Example: `Authorization: Bearer abc.def` → `Authorization: Bearer [REDACTED_TOKEN]`
 
 #### Scenario: OpenAI-style API keys
 - **WHEN** text contains an `sk-...` style API key
 - **THEN** the key is replaced with `[REDACTED_API_KEY]`
+- Pattern example: `\\bsk-[A-Za-z0-9_-]{12,}\\b`
+- Example: `sk-<token>` → `[REDACTED_API_KEY]`
 
 #### Scenario: Private key blocks
 - **WHEN** text contains a PEM private key block
 - **THEN** it is replaced with `[REDACTED_PRIVATE_KEY]`
+- Pattern example: `-----BEGIN ... PRIVATE KEY----- ... -----END ... PRIVATE KEY-----`
+- Example: `-----BEGIN PRIVATE KEY----- ... -----END PRIVATE KEY-----` → `[REDACTED_PRIVATE_KEY]`
+
+#### Scenario: GitHub tokens
+- **WHEN** text contains a GitHub token (e.g. `ghp_...` or `github_pat_...`)
+- **THEN** it is replaced with `[REDACTED_GITHUB_TOKEN]`
+- Pattern example: `\\bgh[pousr]_[A-Za-z0-9]{36,255}\\b` OR `\\bgithub_pat_[A-Za-z0-9_]{22,255}\\b`
+- Example: `ghp_<token>` → `[REDACTED_GITHUB_TOKEN]`
+
+#### Scenario: Slack tokens
+- **WHEN** text contains a Slack token (e.g. `xoxb-...`)
+- **THEN** it is replaced with `[REDACTED_SLACK_TOKEN]`
+- Pattern example: `\\bxox[baprs]-[0-9A-Za-z-]{10,}\\b`
+- Example: `xoxb-<token>` → `[REDACTED_SLACK_TOKEN]`
 
 #### Scenario: Email addresses
 - **WHEN** text contains an email address
 - **THEN** it is replaced with `[REDACTED_EMAIL]`
+- Pattern example: `\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b` (case-insensitive)
+- Example: `test.user+tag@example.co.uk` → `[REDACTED_EMAIL]`
 
 #### Scenario: Phone numbers
 - **WHEN** text contains a phone number (best-effort)
 - **THEN** it is replaced with `[REDACTED_PHONE]`
+- Pattern example: best-effort matcher that replaces digit-heavy phone-like strings, while avoiding ISO dates like `YYYY-MM-DD`
+- Example: `+1 (415) 555-2671` → `[REDACTED_PHONE]`
 
 ### Requirement: Redaction is applied before leaving the local trust boundary
 The system SHALL apply redaction before sending content to external systems.

--- a/openspec/changes/expand-privacy-redaction/tasks.md
+++ b/openspec/changes/expand-privacy-redaction/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Implementation
-- [ ] Add email redaction
-- [ ] Add phone-number redaction (best-effort)
-- [ ] Add additional token/secret patterns as needed
-- [ ] Ensure redaction is applied for OpenNotebook sync, OpenAI generation inputs, and export ZIP generation
+- [x] Add email redaction
+- [x] Add phone-number redaction (best-effort)
+- [x] Add additional token/secret patterns as needed
+- [x] Ensure redaction is applied for OpenNotebook sync, OpenAI generation inputs, and export ZIP generation
 
 ## 2. Validation
-- [ ] Add unit tests for each redaction rule
-- [ ] Add regression tests to ensure redaction does not break markdown formatting
+- [x] Add unit tests for each redaction rule
+- [x] Add regression tests to ensure redaction does not break markdown formatting
 
 ## 3. Documentation
-- [ ] Update spec delta with patterns and examples
+- [x] Update spec delta with patterns and examples
 


### PR DESCRIPTION
Implements OpenSpec change `expand-privacy-redaction`.

- Adds email/phone + additional secret redaction patterns
- Applies redaction at the OpenNotebook adapter boundary (HTTP + filesystem)
- Adds unit/regression tests for redaction rules
- Updates spec delta + checks off tasks

Closes #17
Closes #18