### PR TITLE
feat(bridge): add export center API

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -20,10 +20,17 @@ Service listens on `127.0.0.1:7331` by default.
 - `BRIDGE_HOST` (default: `127.0.0.1`)
 - `BRIDGE_PORT` (default: `7331`)
 - `BRIDGE_DB_PATH` (default: `bridge/.data/bridge.db`)
+- `BRIDGE_EXPORTS_DIR` (default: `<dirname(BRIDGE_DB_PATH)>/exports`)
+
+### Specs (source of truth)
+- OpenSpec change: `openspec/changes/add-export-center-api/specs/bridge-export-center/spec.md`
 
 ## Endpoints
 - `GET /bridge/v1/health` -> `ok`
 - `POST /bridge/v1/import/codex-chat`
+- `POST /bridge/v1/exports`
+- `GET /bridge/v1/exports`
+- `GET /bridge/v1/exports/{export_id}/download`
 - `POST /bridge/v1/projects/{project_id}/generate` -> `501 Not Implemented` (MVP)
 - `POST /bridge/v1/projects/{project_id}/sync/open-notebook` -> `501 Not Implemented` (MVP)
 
@@ -50,4 +57,12 @@ curl -sS http://127.0.0.1:7331/bridge/v1/import/codex-chat \\
     \"exported_at\": \"2025-12-26T00:00:00.000Z\",
     \"codex\": {\"jsonl_text\": \"{\\\\\"type\\\\\":\\\\\"event_msg\\\\\",\\\\\"timestamp\\\\\":\\\\\"2025-12-26T00:00:00.000Z\\\\\",\\\\\"payload\\\\\":{\\\\\"type\\\\\":\\\\\"user_message\\\\\",\\\\\"message\\\\\":\\\\\"hi\\\\\"}}\\n{\\\\\"type\\\\\":\\\\\"event_msg\\\\\",\\\\\"timestamp\\\\\":\\\\\"2025-12-26T00:00:01.000Z\\\\\",\\\\\"payload\\\\\":{\\\\\"type\\\\\":\\\\\"agent_message\\\\\",\\\\\"message\\\\\":\\\\\"hello\\\\\"}}\"}
   }'
+```
+
+Create export ZIP (session scope):
+
+```bash
+curl -sS -X POST http://127.0.0.1:7331/bridge/v1/exports \\
+  -H 'content-type: application/json' \\
+  -d '{"scope":{"project_id":"proj_...","session_id":"sess_..."},"includes":{"sessions":true},"version":"v0.3.4"}'
 ```

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -1,0 +1,1295 @@
+{
+  "name": "bridge-service",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bridge-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.19.2",
+        "fflate": "^0.8.2"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^11.6.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
+      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    }
+  }
+}

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -6,10 +6,12 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "test": "node --test"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "fflate": "^0.8.2"
   },
   "optionalDependencies": {
     "better-sqlite3": "^11.6.0"

--- a/bridge/src/app.js
+++ b/bridge/src/app.js
@@ -1,0 +1,535 @@
+const fs = require("fs");
+const path = require("path");
+const express = require("express");
+
+const { openBridgeDb } = require("./db");
+const { stableId, randomId } = require("./lib/ids");
+const { parseCodexJsonl } = require("./lib/codexJsonl");
+const { sendError } = require("./lib/errors");
+const { FilesystemAdapter, DEFAULT_ENV_VAR: OPEN_NOTEBOOK_FS_ROOT_ENV } = require("./adapters/filesystem");
+const { renderSourceMarkdown, renderPlaceholderNotes } = require("./lib/openNotebookContent");
+const {
+  normalizeExportVersion,
+  normalizeIncludes,
+  makeExportManifest,
+  renderExportIndexMarkdown,
+  buildExportZipBuffer,
+} = require("./lib/exportZip");
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function safeJsonParseArray(text) {
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return null;
+  }
+}
+
+function createBridgeApp(options = {}) {
+  const bodyLimit = options.bodyLimit || process.env.BRIDGE_BODY_LIMIT || "25mb";
+  const dbPath =
+    options.dbPath || process.env.BRIDGE_DB_PATH || path.join(__dirname, "..", ".data", "bridge.db");
+
+  const exportsDir =
+    options.exportsDir ||
+    process.env.BRIDGE_EXPORTS_DIR ||
+    path.join(path.dirname(dbPath), "exports");
+
+  const app = express();
+  const bridgeDb = openBridgeDb(dbPath);
+
+  app.use(express.json({ limit: bodyLimit }));
+
+  app.get("/bridge/v1/health", (req, res) => {
+    res.type("text/plain").send("ok");
+  });
+
+  app.post("/bridge/v1/import/codex-chat", (req, res) => {
+    const body = req.body;
+    if (!body || typeof body !== "object") {
+      return sendError(res, 400, "invalid_request", "Request body must be JSON");
+    }
+
+    const project = body.project;
+    const session = body.session;
+    const codex = body.codex;
+
+    const errors = [];
+    if (!project || typeof project !== "object") errors.push("project must be an object");
+    if (!session || typeof session !== "object") errors.push("session must be an object");
+    if (!codex || typeof codex !== "object") errors.push("codex must be an object");
+
+    const projectName = project && typeof project.name === "string" ? project.name.trim() : "";
+    const projectCwd = project && typeof project.cwd === "string" ? project.cwd.trim() : "";
+    const sessionName = session && typeof session.name === "string" ? session.name.trim() : "";
+    const exportedAt = typeof body.exported_at === "string" ? body.exported_at.trim() : "";
+    const jsonlText = codex && typeof codex.jsonl_text === "string" ? codex.jsonl_text : "";
+
+    if (!projectName) errors.push("project.name must be a non-empty string");
+    if (!projectCwd) errors.push("project.cwd must be a non-empty string");
+    if (!sessionName) errors.push("session.name must be a non-empty string");
+    if (!exportedAt) errors.push("exported_at must be a non-empty string (ISO-8601 recommended)");
+    if (!jsonlText) errors.push("codex.jsonl_text must be a non-empty string");
+
+    if (errors.length > 0) {
+      return sendError(res, 400, "invalid_request", "Invalid import payload", { errors });
+    }
+
+    const warnings = [];
+    const parsedExportedAtMs = Date.parse(exportedAt);
+    if (!Number.isFinite(parsedExportedAtMs)) {
+      warnings.push({
+        code: "invalid_exported_at",
+        message: "exported_at is not a valid ISO-8601 timestamp; accepted but may reduce traceability",
+      });
+    }
+
+    const { message_count, messages, warnings: parseWarnings } = parseCodexJsonl(jsonlText);
+    for (const w of parseWarnings) warnings.push(w);
+
+    const project_id = stableId("proj", projectCwd);
+    const session_id = stableId("sess", project_id, sessionName);
+
+    const now = new Date().toISOString();
+    try {
+      bridgeDb.transaction(() => {
+        bridgeDb.ensureProject({
+          id: project_id,
+          name: projectName,
+          cwd: projectCwd,
+          created_at: now,
+        });
+        bridgeDb.ensureSession({
+          id: session_id,
+          project_id,
+          name: sessionName,
+          imported_at: now,
+          source_type: "codex_jsonl",
+        });
+        bridgeDb.addSource({
+          id: randomId("src"),
+          session_id,
+          exported_at: exportedAt,
+          raw_jsonl: jsonlText,
+          normalized_json: JSON.stringify(messages),
+          warnings_json: JSON.stringify(warnings),
+          message_count,
+          created_at: now,
+        });
+      });
+    } catch (err) {
+      return sendError(res, 500, "db_error", "Failed to persist import into SQLite", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    res.json({
+      project_id,
+      session_id,
+      message_count,
+      warnings,
+    });
+  });
+
+  app.post("/bridge/v1/exports", (req, res) => {
+    const body = req.body;
+    if (!body || typeof body !== "object") {
+      return sendError(res, 400, "invalid_request", "Request body must be JSON");
+    }
+
+    const scope = body.scope;
+    const includesRaw = body.includes;
+    const includeRawJsonl = body.include_raw_jsonl === true;
+    const version = normalizeExportVersion(body.version);
+
+    const errors = [];
+    if (!scope || typeof scope !== "object") errors.push("scope must be an object");
+    if (includesRaw != null && typeof includesRaw !== "object") errors.push("includes must be an object");
+
+    const projectId = scope && typeof scope.project_id === "string" ? scope.project_id.trim() : "";
+    const sessionId = scope && typeof scope.session_id === "string" ? scope.session_id.trim() : "";
+
+    if (!projectId) errors.push("scope.project_id must be a non-empty string");
+    if (!sessionId) errors.push("scope.session_id must be a non-empty string");
+
+    if (errors.length > 0) {
+      return sendError(res, 400, "invalid_request", "Invalid export request", { errors });
+    }
+
+    const includes = normalizeIncludes(includesRaw);
+
+    const projectRow = bridgeDb.getProjectById(projectId);
+    if (!projectRow) {
+      return sendError(res, 404, "not_found", "Project not found", { project_id: projectId });
+    }
+
+    const sessionRow = bridgeDb.getSessionById(sessionId);
+    if (!sessionRow) {
+      return sendError(res, 404, "not_found", "Session not found", { session_id: sessionId });
+    }
+    if (sessionRow.project_id !== projectId) {
+      return sendError(res, 400, "invalid_request", "session_id does not belong to project_id", {
+        project_id: projectId,
+        session_id: sessionId,
+      });
+    }
+
+    const sourceRow = bridgeDb.getLatestSourceBySessionId(sessionId);
+    if (!sourceRow) {
+      return sendError(res, 404, "not_found", "No imported source found for session", { session_id: sessionId });
+    }
+
+    const messages = safeJsonParseArray(sourceRow.normalized_json);
+    if (messages == null) {
+      return sendError(res, 500, "invalid_state", "Failed to parse normalized_json for session source", {
+        session_id: sessionId,
+      });
+    }
+
+    const export_id = randomId("exp");
+    const created_at = new Date().toISOString();
+
+    const scopeJson = { project_id: projectId, session_id: sessionId };
+    const warnings = [];
+
+    ensureDir(exportsDir);
+    const zipPath = path.join(exportsDir, `${export_id}.zip`);
+
+    const counts = {
+      sessions: includes.sessions ? 1 : 0,
+      tech_cards: includes.tech_cards ? 0 : 0,
+      playbooks: includes.playbooks ? 0 : 0,
+      practices: includes.practices ? 0 : 0,
+    };
+
+    const replayBaseUrl = (process.env.BRIDGE_PUBLIC_BASE_URL || "").trim() || `${req.protocol}://${req.get("host")}`;
+    const manifest = makeExportManifest({
+      version,
+      export_id,
+      created_at,
+      scope: scopeJson,
+      counts,
+      replay_base_url: replayBaseUrl,
+    });
+
+    const sessionFileBase = sessionRow.id.replace(/[^A-Za-z0-9_-]/g, "_");
+    const sessionMdPath = path.posix.join("Sessions", `${sessionFileBase}.md`);
+    const sessionJsonlPath = path.posix.join("Sessions", `${sessionFileBase}.jsonl`);
+
+    const sessionMarkdown = renderSourceMarkdown({
+      project: { id: projectRow.id, name: projectRow.name, cwd: projectRow.cwd },
+      session: { id: sessionRow.id, name: sessionRow.name },
+      project_id: projectId,
+      session_id: sessionId,
+      messages,
+    });
+
+    const index_markdown = renderExportIndexMarkdown({
+      export_id,
+      created_at,
+      scope: scopeJson,
+      session_links: includes.sessions ? [`[${sessionRow.name}](${sessionMdPath})`] : [],
+    });
+
+    const zipFiles = {};
+    if (includes.sessions) zipFiles[sessionMdPath] = sessionMarkdown;
+    if (includes.sessions && includeRawJsonl) zipFiles[sessionJsonlPath] = sourceRow.raw_jsonl;
+
+    try {
+      bridgeDb.createExport({
+        id: export_id,
+        project_id: projectId,
+        session_id: sessionId,
+        scope_json: JSON.stringify(scopeJson),
+        includes_json: JSON.stringify(includes),
+        status: "building",
+        created_at,
+        version,
+        zip_path: null,
+        counts_json: JSON.stringify({}),
+        warnings_json: JSON.stringify(warnings),
+        error_json: null,
+      });
+    } catch (err) {
+      return sendError(res, 500, "db_error", "Failed to create export record", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    try {
+      const zipBuffer = buildExportZipBuffer({
+        index_markdown,
+        manifest,
+        files: zipFiles,
+      });
+
+      fs.writeFileSync(zipPath, zipBuffer);
+
+      bridgeDb.updateExport({
+        id: export_id,
+        status: "ready",
+        zip_path: zipPath,
+        counts_json: JSON.stringify(counts),
+        warnings_json: JSON.stringify(warnings),
+        error_json: null,
+      });
+    } catch (err) {
+      try {
+        bridgeDb.updateExport({
+          id: export_id,
+          status: "failed",
+          zip_path: null,
+          counts_json: JSON.stringify(counts),
+          warnings_json: JSON.stringify(warnings),
+          error_json: JSON.stringify({ message: err instanceof Error ? err.message : String(err) }),
+        });
+      } catch {}
+
+      return sendError(res, 500, "export_failed", "Failed to build export ZIP", {
+        export_id,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    res.json({
+      export_id,
+      status: "ready",
+      created_at,
+      download_url: `/bridge/v1/exports/${export_id}/download`,
+      warnings,
+    });
+  });
+
+  app.get("/bridge/v1/exports", (req, res) => {
+    const rows = bridgeDb.listExports({ limit: 100 });
+    const exportsList = rows.map((r) => {
+      let scope = {};
+      try {
+        scope = JSON.parse(r.scope_json);
+      } catch {}
+
+      return {
+        export_id: r.id,
+        status: r.status,
+        created_at: r.created_at,
+        scope,
+        download_url: r.status === "ready" ? `/bridge/v1/exports/${r.id}/download` : null,
+      };
+    });
+
+    res.json({ exports: exportsList });
+  });
+
+  app.get("/bridge/v1/exports/:export_id/download", (req, res) => {
+    const exportId = String(req.params.export_id || "");
+    if (!exportId) {
+      return sendError(res, 400, "invalid_request", "export_id must be provided");
+    }
+
+    const row = bridgeDb.getExportById(exportId);
+    if (!row) {
+      return sendError(res, 404, "not_found", "Export not found", { export_id: exportId });
+    }
+
+    if (row.status !== "ready") {
+      return sendError(res, 409, "invalid_state", "Export is not ready for download", {
+        export_id: exportId,
+        status: row.status,
+      });
+    }
+
+    const zipPath = row.zip_path ? String(row.zip_path) : "";
+    if (!zipPath) {
+      return sendError(res, 500, "invalid_state", "Export ZIP path is missing", { export_id: exportId });
+    }
+    if (!fs.existsSync(zipPath)) {
+      return sendError(res, 500, "invalid_state", "Export ZIP file is missing on disk", {
+        export_id: exportId,
+      });
+    }
+
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="export-${exportId}.zip"`);
+    res.sendFile(path.resolve(zipPath));
+  });
+
+  app.post("/bridge/v1/projects/:project_id/generate", (req, res) => {
+    const projectId = String(req.params.project_id || "");
+    return sendError(res, 501, "not_implemented", "Generate is not implemented in Bridge MVP", {
+      project_id: projectId,
+      route: "POST /bridge/v1/projects/:project_id/generate",
+    });
+  });
+
+  app.post("/bridge/v1/projects/:project_id/sync/open-notebook", (req, res) => {
+    const projectId = String(req.params.project_id || "");
+
+    const body = req.body;
+    if (!body || typeof body !== "object") {
+      return sendError(res, 400, "invalid_request", "Request body must be JSON");
+    }
+
+    const sessionId = typeof body.session_id === "string" ? body.session_id.trim() : "";
+    const targetsRaw = body.targets;
+
+    if (!sessionId) {
+      return sendError(res, 400, "invalid_request", "session_id must be a non-empty string");
+    }
+
+    let targets = ["sources", "notes"];
+    if (Array.isArray(targetsRaw)) {
+      targets = targetsRaw.map((t) => String(t || "").trim()).filter(Boolean);
+    }
+
+    const wantSources = targets.includes("sources");
+    const wantNotes = targets.includes("notes");
+    if (!wantSources && !wantNotes) {
+      return sendError(res, 400, "invalid_request", "targets must include at least one of: sources, notes");
+    }
+
+    const rootDir = (process.env[OPEN_NOTEBOOK_FS_ROOT_ENV] || "").trim();
+    if (!rootDir) {
+      return sendError(
+        res,
+        400,
+        "invalid_request",
+        `OpenNotebook filesystem root is not set. Please set ${OPEN_NOTEBOOK_FS_ROOT_ENV} to a writable directory.`,
+      );
+    }
+
+    const projectRow = bridgeDb.getProjectById(projectId);
+    if (!projectRow) {
+      return sendError(res, 404, "not_found", "Project not found", { project_id: projectId });
+    }
+
+    const sessionRow = bridgeDb.getSessionById(sessionId);
+    if (!sessionRow) {
+      return sendError(res, 404, "not_found", "Session not found", { session_id: sessionId });
+    }
+    if (sessionRow.project_id !== projectId) {
+      return sendError(res, 400, "invalid_request", "session_id does not belong to project_id", {
+        project_id: projectId,
+        session_id: sessionId,
+      });
+    }
+
+    const sourceRow = bridgeDb.getLatestSourceBySessionId(sessionId);
+    if (!sourceRow) {
+      return sendError(res, 404, "not_found", "No imported source found for session", { session_id: sessionId });
+    }
+
+    const messages = safeJsonParseArray(sourceRow.normalized_json);
+    if (messages == null) {
+      return sendError(res, 500, "invalid_state", "Failed to parse normalized_json for session source", {
+        session_id: sessionId,
+      });
+    }
+
+    const adapter = FilesystemAdapter.fromEnv(OPEN_NOTEBOOK_FS_ROOT_ENV);
+
+    const notebookProjectKey = projectRow.cwd;
+    const notebookIdPromise = adapter.createOrGetNotebook(notebookProjectKey);
+
+    Promise.resolve(notebookIdPromise)
+      .then(async (notebookId) => {
+        const project = { id: projectRow.id, name: projectRow.name, cwd: projectRow.cwd };
+        const session = { id: sessionRow.id, name: sessionRow.name };
+
+        let sourceId = null;
+        if (wantSources) {
+          const sourceMarkdown = renderSourceMarkdown({
+            project,
+            session,
+            project_id: projectId,
+            session_id: sessionId,
+            messages,
+          });
+          sourceId = await adapter.upsertSource(notebookId, sessionId, sourceMarkdown);
+        }
+
+        const noteIds = {};
+        const noteKinds = [];
+        if (wantNotes) {
+          if (!sourceId) {
+            return sendError(res, 500, "invalid_state", "Cannot write notes without sources in MVP sync", {
+              project_id: projectId,
+              session_id: sessionId,
+            });
+          }
+
+          const notes = renderPlaceholderNotes({
+            project,
+            session,
+            project_id: projectId,
+            session_id: sessionId,
+            sourceId,
+            messages,
+          });
+
+          noteKinds.push("summary", "study-pack", "milestones");
+
+          const links = [];
+          if (messages.length >= 1) links.push("m-000001");
+          if (messages.length >= 2) links.push("m-000002");
+          if (messages.length >= 3) links.push("m-000003");
+
+          for (const kind of noteKinds) {
+            const content = notes[kind] || notes[kind.replace(/_/g, "-")] || "";
+            noteIds[kind] = await adapter.upsertNote(notebookId, kind, content, links);
+          }
+        }
+
+        res.json({
+          notebook: {
+            adapter: "filesystem",
+            root_dir: rootDir,
+            project_key: notebookProjectKey,
+            notebook_id: notebookId,
+          },
+          project_id: projectId,
+          session_id: sessionId,
+          source_id: sourceId,
+          notes: noteIds,
+        });
+      })
+      .catch((err) => {
+        return sendError(res, 500, "sync_failed", "Failed to sync to OpenNotebook filesystem adapter", {
+          project_id: projectId,
+          session_id: sessionId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+  });
+
+  app.use((req, res) => {
+    return sendError(res, 404, "not_found", "Route not found", {
+      method: req.method,
+      path: req.originalUrl,
+    });
+  });
+
+  app.use((err, req, res, next) => {
+    if (res.headersSent) return next(err);
+    if (err && err.type === "entity.too.large") {
+      return sendError(res, 413, "payload_too_large", "JSON body too large");
+    }
+    if (err && (err.type === "entity.parse.failed" || err instanceof SyntaxError)) {
+      return sendError(res, 400, "invalid_json", "Invalid JSON in request body");
+    }
+    return sendError(res, 500, "internal_error", "Unexpected server error");
+  });
+
+  return {
+    app,
+    bridgeDb,
+    dbPath,
+    exportsDir,
+  };
+}
+
+module.exports = { createBridgeApp };
+

--- a/bridge/src/lib/exportZip.js
+++ b/bridge/src/lib/exportZip.js
@@ -1,0 +1,79 @@
+const { zipSync, strToU8 } = require("fflate");
+
+function normalizeExportVersion(versionRaw) {
+  const v = String(versionRaw || "").trim();
+  return v || "v0.3.4";
+}
+
+function normalizeIncludes(includesRaw) {
+  const obj = includesRaw && typeof includesRaw === "object" ? includesRaw : {};
+  return {
+    sessions: obj.sessions !== false,
+    tech_cards: obj.tech_cards === true,
+    playbooks: obj.playbooks === true,
+    practices: obj.practices === true,
+  };
+}
+
+function makeExportManifest({ version, export_id, created_at, scope, counts, replay_base_url }) {
+  return {
+    version: normalizeExportVersion(version),
+    export_id: String(export_id || ""),
+    created_at: String(created_at || ""),
+    scope: scope && typeof scope === "object" ? scope : {},
+    counts: counts && typeof counts === "object" ? counts : {},
+    replay: replay_base_url ? { base_url: String(replay_base_url) } : undefined,
+  };
+}
+
+function renderExportIndexMarkdown({ export_id, created_at, scope, session_links = [] }) {
+  const lines = [];
+  lines.push("# Export Bundle", "");
+  if (export_id) lines.push(`- export_id: \`${export_id}\``);
+  if (created_at) lines.push(`- created_at: \`${created_at}\``);
+  if (scope && typeof scope === "object") {
+    if (scope.project_id) lines.push(`- project_id: \`${scope.project_id}\``);
+    if (scope.session_id) lines.push(`- session_id: \`${scope.session_id}\``);
+  }
+  lines.push("", "## Sessions", "");
+  if (!session_links.length) {
+    lines.push("- (none)");
+  } else {
+    for (const link of session_links) {
+      lines.push(`- ${link}`);
+    }
+  }
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+function buildExportZipBuffer({ index_markdown, manifest, files = {} }) {
+  const entries = {
+    "00_Index.md": strToU8(String(index_markdown || "")),
+    "manifest.json": strToU8(`${JSON.stringify(manifest || {}, null, 2)}\n`),
+    "Sessions/": new Uint8Array(0),
+    "TechCards/": new Uint8Array(0),
+    "Playbooks/": new Uint8Array(0),
+    "Practices/": new Uint8Array(0),
+  };
+
+  for (const [name, value] of Object.entries(files || {})) {
+    if (!name || typeof name !== "string") continue;
+    if (value == null) continue;
+    if (value instanceof Uint8Array) {
+      entries[name] = value;
+      continue;
+    }
+    entries[name] = strToU8(String(value));
+  }
+
+  return Buffer.from(zipSync(entries, { level: 6 }));
+}
+
+module.exports = {
+  normalizeExportVersion,
+  normalizeIncludes,
+  makeExportManifest,
+  renderExportIndexMarkdown,
+  buildExportZipBuffer,
+};
+

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -1,3 +1,4 @@
+if (false) {
 const path = require("path");
 const express = require("express");
 const { openBridgeDb } = require("./db");
@@ -310,4 +311,52 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, HOST, () => {
   console.log(`Bridge listening on http://${HOST}:${PORT}`);
+});
+}
+
+const { createBridgeApp } = require("./app");
+
+const HOST = process.env.BRIDGE_HOST || "127.0.0.1";
+const PORT_RAW = process.env.BRIDGE_PORT || "7331";
+const PORT = Number(PORT_RAW);
+
+if (!Number.isFinite(PORT) || PORT <= 0) {
+  console.error(`Invalid BRIDGE_PORT: ${PORT_RAW}`);
+  process.exit(1);
+}
+
+let appInfo;
+try {
+  appInfo = createBridgeApp();
+  console.log(`Bridge DB: ${appInfo.dbPath} (${appInfo.bridgeDb.driver})`);
+  console.log(`Bridge exports dir: ${appInfo.exportsDir}`);
+} catch (err) {
+  console.error("Failed to start Bridge.");
+  if (err && typeof err === "object") {
+    const code = err.code ? String(err.code) : "";
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(code ? `[${code}] ${msg}` : msg);
+    if (err.details) {
+      try {
+        console.error(JSON.stringify(err.details, null, 2));
+      } catch {}
+    }
+  } else {
+    console.error(String(err));
+  }
+  process.exit(1);
+}
+
+const server = appInfo.app.listen(PORT, HOST, () => {
+  console.log(`Bridge listening on http://${HOST}:${PORT}`);
+});
+
+process.on("SIGINT", () => {
+  try {
+    if (server && typeof server.close === "function") server.close();
+  } catch {}
+  try {
+    if (appInfo && appInfo.bridgeDb && typeof appInfo.bridgeDb.close === "function") appInfo.bridgeDb.close();
+  } catch {}
+  process.exit(0);
 });

--- a/bridge/test/exportApi.test.js
+++ b/bridge/test/exportApi.test.js
@@ -1,0 +1,93 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { unzipSync } = require("fflate");
+
+const { createBridgeApp } = require("../src/app");
+
+function makeTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("export create/list/download happy path", async (t) => {
+  const tmpDir = makeTempDir("bridge-export-");
+  const dbPath = path.join(tmpDir, "bridge.db");
+  const exportsDir = path.join(tmpDir, "exports");
+
+  const { app, bridgeDb } = createBridgeApp({ dbPath, exportsDir });
+
+  const now = new Date().toISOString();
+  const project_id = "proj_test";
+  const session_id = "sess_test";
+
+  bridgeDb.transaction(() => {
+    bridgeDb.ensureProject({ id: project_id, name: "Demo", cwd: "/tmp/demo", created_at: now });
+    bridgeDb.ensureSession({ id: session_id, project_id, name: "Session 1", imported_at: now, source_type: "codex_jsonl" });
+    bridgeDb.addSource({
+      id: "src_test",
+      session_id,
+      exported_at: now,
+      raw_jsonl: '{"type":"event_msg","timestamp":"2026-01-03T00:00:00Z","payload":{"type":"user_message","message":"hi"}}',
+      normalized_json: JSON.stringify([{ role: "user", timestamp: now, text: "hi" }]),
+      warnings_json: "[]",
+      message_count: 1,
+      created_at: now,
+    });
+  });
+
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+
+  const addr = server.address();
+  const port = addr && typeof addr === "object" ? addr.port : null;
+  assert.ok(port, "failed to bind server port");
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(() => {
+    try {
+      server.close();
+    } catch {}
+    try {
+      bridgeDb.close();
+    } catch {}
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  const createResp = await fetch(`${baseUrl}/bridge/v1/exports`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      scope: { project_id, session_id },
+      includes: { sessions: true },
+      version: "v0.3.4",
+      include_raw_jsonl: false,
+    }),
+  });
+  assert.equal(createResp.status, 200);
+  const created = await createResp.json();
+  assert.ok(created.export_id);
+  assert.equal(created.status, "ready");
+  assert.equal(created.download_url, `/bridge/v1/exports/${created.export_id}/download`);
+
+  const listResp = await fetch(`${baseUrl}/bridge/v1/exports`);
+  assert.equal(listResp.status, 200);
+  const listed = await listResp.json();
+  assert.ok(Array.isArray(listed.exports));
+  assert.equal(listed.exports[0].export_id, created.export_id);
+
+  const downloadResp = await fetch(`${baseUrl}${created.download_url}`);
+  assert.equal(downloadResp.status, 200);
+  assert.equal(downloadResp.headers.get("content-type"), "application/zip");
+
+  const zipBytes = new Uint8Array(await downloadResp.arrayBuffer());
+  const entries = unzipSync(zipBytes);
+  assert.ok(entries["00_Index.md"]);
+  assert.ok(entries["manifest.json"]);
+});
+

--- a/bridge/test/exportZip.test.js
+++ b/bridge/test/exportZip.test.js
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { unzipSync } = require("fflate");
+
+const {
+  makeExportManifest,
+  renderExportIndexMarkdown,
+  buildExportZipBuffer,
+} = require("../src/lib/exportZip");
+
+test("export ZIP contains stable layout + manifest", () => {
+  const manifest = makeExportManifest({
+    version: "v0.3.4",
+    export_id: "exp_test",
+    created_at: "2026-01-03T00:00:00Z",
+    scope: { project_id: "proj_test", session_id: "sess_test" },
+    counts: { sessions: 1, tech_cards: 0, playbooks: 0, practices: 0 },
+    replay_base_url: "http://127.0.0.1:7331",
+  });
+
+  const index = renderExportIndexMarkdown({
+    export_id: "exp_test",
+    created_at: "2026-01-03T00:00:00Z",
+    scope: { project_id: "proj_test", session_id: "sess_test" },
+    session_links: ["[sess_test](Sessions/sess_test.md)"],
+  });
+
+  const zip = buildExportZipBuffer({
+    index_markdown: index,
+    manifest,
+    files: {
+      "Sessions/sess_test.md": "# Session\n",
+    },
+  });
+
+  const entries = unzipSync(new Uint8Array(zip));
+
+  assert.ok(entries["00_Index.md"], "00_Index.md missing");
+  assert.ok(entries["manifest.json"], "manifest.json missing");
+
+  const parsedManifest = JSON.parse(Buffer.from(entries["manifest.json"]).toString("utf8"));
+  assert.equal(parsedManifest.export_id, "exp_test");
+  assert.equal(parsedManifest.version, "v0.3.4");
+  assert.equal(parsedManifest.scope.project_id, "proj_test");
+  assert.equal(parsedManifest.scope.session_id, "sess_test");
+});
+

--- a/openspec/changes/add-export-center-api/specs/bridge-export-center/spec.md
+++ b/openspec/changes/add-export-center-api/specs/bridge-export-center/spec.md
@@ -3,10 +3,11 @@
 ### Requirement: Create export bundles
 Bridge SHALL provide `POST /bridge/v1/exports` to create a Markdown ZIP export for a given scope and includes list.
 
-#### Scenario: Create an export for a project
-- **WHEN** the client posts a valid export request (scope/includes/version)
+#### Scenario: Create an export for a session
+- **WHEN** the client posts a valid export request with `scope.project_id` and `scope.session_id`
+- **AND** `includes` is omitted or an object of boolean flags
 - **THEN** Bridge creates an export record and produces a ZIP artifact
-- **AND** the response includes an `export_id` and a `download_url`
+- **AND** the response includes an `export_id`, `status`, `created_at`, and a `download_url`
 
 ### Requirement: List exports
 Bridge SHALL provide `GET /bridge/v1/exports` to list prior exports with status and download link.
@@ -14,13 +15,14 @@ Bridge SHALL provide `GET /bridge/v1/exports` to list prior exports with status 
 #### Scenario: List returns newest first
 - **WHEN** the client requests the export list
 - **THEN** Bridge returns a list ordered by most recent first
+- **AND** each item includes `export_id`, `status`, `created_at`, `scope`, and a `download_url` when ready
 
 ### Requirement: Download ZIP
 Bridge SHALL provide `GET /bridge/v1/exports/{export_id}/download` to download the ZIP for a completed export.
 
 #### Scenario: Download completed export
-- **WHEN** the export exists and is completed
-- **THEN** Bridge returns the ZIP bytes with appropriate content type
+- **WHEN** the export exists and is `ready`
+- **THEN** Bridge returns the ZIP bytes with `Content-Type: application/zip`
 
 ### Requirement: Stable ZIP layout
 The ZIP artifact SHALL have a stable directory layout and include a machine-readable `manifest.json`.
@@ -28,4 +30,6 @@ The ZIP artifact SHALL have a stable directory layout and include a machine-read
 #### Scenario: ZIP contains required files
 - **WHEN** a ZIP is downloaded
 - **THEN** it contains `00_Index.md` and `manifest.json` at the root
+- **AND** it includes top-level folders: `Sessions/`, `TechCards/`, `Playbooks/`, and `Practices/`
+- **AND** `manifest.json` includes `version`, `export_id`, `created_at`, `scope`, and `counts`
 

--- a/openspec/changes/add-export-center-api/tasks.md
+++ b/openspec/changes/add-export-center-api/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Implementation
-- [ ] Add DB table(s) for exports (id, project_id, scope, includes, status, created_at, zip_path/url, counts, version)
-- [ ] Implement `POST /bridge/v1/exports` (create export)
-- [ ] Implement `GET /bridge/v1/exports` (list exports)
-- [ ] Implement `GET /bridge/v1/exports/{export_id}/download` (download ZIP)
-- [ ] Implement ZIP builder with stable layout + `manifest.json`
-- [ ] Add minimal validation and consistent error responses
+- [x] Add DB table(s) for exports (id, project_id, scope, includes, status, created_at, zip_path/url, counts, version)
+- [x] Implement `POST /bridge/v1/exports` (create export)
+- [x] Implement `GET /bridge/v1/exports` (list exports)
+- [x] Implement `GET /bridge/v1/exports/{export_id}/download` (download ZIP)
+- [x] Implement ZIP builder with stable layout + `manifest.json`
+- [x] Add minimal validation and consistent error responses
 
 ## 2. Validation
-- [ ] Add unit tests for ZIP layout + manifest generation
-- [ ] Add API-level tests for create/list/download happy path
+- [x] Add unit tests for ZIP layout + manifest generation
+- [x] Add API-level tests for create/list/download happy path
 
 ## 3. Documentation
-- [ ] Update the existing repo docs to reference the OpenSpec capability as the source of truth
+- [x] Update the existing repo docs to reference the OpenSpec capability as the source of truth
 


### PR DESCRIPTION
Implements OpenSpec change `add-export-center-api` (DB schema + Export Center APIs + ZIP bundle builder + tests).

Closes #9
Closes #10
Closes #11
Closes #12
Closes #13